### PR TITLE
Fix README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ func main() {
 		Func: func(args []string) {
 			fmt.Println("I do nothing...")
 		},
-	}
+	})
 
 	c.Run()
 


### PR DESCRIPTION
Line 66 containing the example code was missing a closing round bracket.